### PR TITLE
add query param to exclude applause from calculations closes #37

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The `sentiment` is the sum of the sentiments of all messages that were aggregate
 |---------|--------------------------------------------------------------------|------------------------------|
 | filter  | Limits the messages to only those with the given type of sentiment | `POSITIVE`, `NEGATIVE`       |
 | session | Limits the messages to only those from the given session           | any sessionId from `/sessions` |
+| exclude_applause | Filters out all messages which are flagged as applause    | `true`                       |
 
 #### Sample Data
 ```json
@@ -138,6 +139,7 @@ returns the page-ranked factions from group5 database
 | filter  | Limits the messages used for page rank calculation to only those with the given type of sentiment | `POSITIVE`, `NEGATIVE`       |
 | session | Limits the messages used for page rank calculation to only those from the given session           | any sessionId from `/sessions` |
 | reverse | Uses the ''Reverse PageRank'' for page rank calculation                                           | `true`                       |
+| exclude_applause | Filters out all messages which are flagged as applause                                   | `true`                       |
 
 
 #### Sample Data
@@ -165,6 +167,7 @@ returns speech proportions of each faction in percentage, regarding all sessions
 | Name    | Description                                                                                       | Allowed Values                 |
 |---------|---------------------------------------------------------------------------------------------------|--------------------------------|
 | session | Limits the messages used for proportion calculation to only those from the given session          | any sessionId from `/sessions` |
+| exclude_applause | Filters out all messages which are flagged as applause                                   | `true`                       |
 
 #### Sample Data
 ```json
@@ -187,6 +190,11 @@ returns speech proportions of each faction in percentage, regarding all sessions
 ### `factions/sentiment/key_figures`
 
 returns the calculated key figures of sentiments between all factions
+
+| Name    | Description                                                                                       | Allowed Values                 |
+|---------|---------------------------------------------------------------------------------------------------|--------------------------------|
+| session | Limits the messages used for key figures calculation to only those from the given session         | any sessionId from `/sessions` |
+| exclude_applause | Filters out all messages which are flagged as applause                                   | `true`                       |
 
 #### Sample Data
 ```json
@@ -245,6 +253,8 @@ returns all messages from group4 database. The messages are not aggregated in an
 | filter  | Limits the messages to only those with the given type of sentiment | `POSITIVE`, `NEGATIVE`         |
 | session | Limits the messages to only those from the given session           | any sessionId from `/sessions` |
 | person  | Limits the messages to only those from the given person            | any speakerId from `/persons`  |
+| exclude_applause | Filters out all messages which are flagged as applause    | `true`                       |
+
 #### Sample Data
 ```json
 [
@@ -277,6 +287,8 @@ The `sentiment` is the sum of the sentiments of all messages that were aggregate
 | filter  | Limits the messages to only those with the given type of sentiment and the persons to only those connected to messages with the given type of sentiment | `POSITIVE`, `NEGATIVE`         |
 | session | Limits the messages to only those from the given session the persons to only those connected to messages in the given session                           | any sessionId from `/sessions` |
 | person  | Limits the messages to only those from the given person and the persons information to only those connected to the given person                         | any speakerId from `/persons`  |
+| exclude_applause | Filters out all messages which are flagged as applause                                                                                         | `true`                       |
+
 #### Sample Data
 ```json
 {
@@ -328,6 +340,7 @@ returns the page-ranked persons from group4 database
 | filter  | Limits the messages used for page rank calculation to only those with the given type of sentiment | `POSITIVE`, `NEGATIVE`       |
 | session | Limits the messages used for page rank calculation to only those from the given session           | any sessionId from `/sessions` |
 | reverse | Uses the ''Reverse PageRank'' for page rank calculation                                           | `true`                       |
+| exclude_applause | Filters out all messages which are flagged as applause                                   | `true`                       |
 
 #### Sample Data
 ```json
@@ -362,6 +375,8 @@ returns the calculated key figures of sentiments between all persons
 | Name      | Description                                                                                    | Allowed Values                 |
 |-----------|------------------------------------------------------------------------------------------------|--------------------------------|
 | session   | Limits the messages used for key figures calculation to only those from the given session      | any sessionId from `/sessions` |
+| exclude_applause | Filters out all messages which are flagged as applause                                  | `true`                       |
+
 
 #### Sample Data
 ```json

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The `sentiment` is the sum of the sentiments of all messages that were aggregate
 |---------|--------------------------------------------------------------------|------------------------------|
 | filter  | Limits the messages to only those with the given type of sentiment | `POSITIVE`, `NEGATIVE`       |
 | session | Limits the messages to only those from the given session           | any sessionId from `/sessions` |
-| exclude_applause | Filters out all messages which are flagged as applause    | `true`                       |
+| excludeApplause | Filters out all messages which are flagged as applause     | `true`                       |
 
 #### Sample Data
 ```json
@@ -139,7 +139,7 @@ returns the page-ranked factions from group5 database
 | filter  | Limits the messages used for page rank calculation to only those with the given type of sentiment | `POSITIVE`, `NEGATIVE`       |
 | session | Limits the messages used for page rank calculation to only those from the given session           | any sessionId from `/sessions` |
 | reverse | Uses the ''Reverse PageRank'' for page rank calculation                                           | `true`                       |
-| exclude_applause | Filters out all messages which are flagged as applause                                   | `true`                       |
+| excludeApplause | Filters out all messages which are flagged as applause                                    | `true`                       |
 
 
 #### Sample Data
@@ -167,7 +167,7 @@ returns speech proportions of each faction in percentage, regarding all sessions
 | Name    | Description                                                                                       | Allowed Values                 |
 |---------|---------------------------------------------------------------------------------------------------|--------------------------------|
 | session | Limits the messages used for proportion calculation to only those from the given session          | any sessionId from `/sessions` |
-| exclude_applause | Filters out all messages which are flagged as applause                                   | `true`                       |
+| excludeApplause | Filters out all messages which are flagged as applause                                    | `true`                       |
 
 #### Sample Data
 ```json
@@ -194,7 +194,7 @@ returns the calculated key figures of sentiments between all factions
 | Name    | Description                                                                                       | Allowed Values                 |
 |---------|---------------------------------------------------------------------------------------------------|--------------------------------|
 | session | Limits the messages used for key figures calculation to only those from the given session         | any sessionId from `/sessions` |
-| exclude_applause | Filters out all messages which are flagged as applause                                   | `true`                       |
+| excludeApplause | Filters out all messages which are flagged as applause                                    | `true`                       |
 
 #### Sample Data
 ```json
@@ -253,7 +253,7 @@ returns all messages from group4 database. The messages are not aggregated in an
 | filter  | Limits the messages to only those with the given type of sentiment | `POSITIVE`, `NEGATIVE`         |
 | session | Limits the messages to only those from the given session           | any sessionId from `/sessions` |
 | person  | Limits the messages to only those from the given person            | any speakerId from `/persons`  |
-| exclude_applause | Filters out all messages which are flagged as applause    | `true`                       |
+| excludeApplause | Filters out all messages which are flagged as applause     | `true`                       |
 
 #### Sample Data
 ```json
@@ -287,7 +287,7 @@ The `sentiment` is the sum of the sentiments of all messages that were aggregate
 | filter  | Limits the messages to only those with the given type of sentiment and the persons to only those connected to messages with the given type of sentiment | `POSITIVE`, `NEGATIVE`         |
 | session | Limits the messages to only those from the given session the persons to only those connected to messages in the given session                           | any sessionId from `/sessions` |
 | person  | Limits the messages to only those from the given person and the persons information to only those connected to the given person                         | any speakerId from `/persons`  |
-| exclude_applause | Filters out all messages which are flagged as applause                                                                                         | `true`                       |
+| excludeApplause | Filters out all messages which are flagged as applause                                                                                          | `true`                       |
 
 #### Sample Data
 ```json
@@ -340,7 +340,7 @@ returns the page-ranked persons from group4 database
 | filter  | Limits the messages used for page rank calculation to only those with the given type of sentiment | `POSITIVE`, `NEGATIVE`       |
 | session | Limits the messages used for page rank calculation to only those from the given session           | any sessionId from `/sessions` |
 | reverse | Uses the ''Reverse PageRank'' for page rank calculation                                           | `true`                       |
-| exclude_applause | Filters out all messages which are flagged as applause                                   | `true`                       |
+| excludeApplause | Filters out all messages which are flagged as applause                                    | `true`                       |
 
 #### Sample Data
 ```json
@@ -375,7 +375,7 @@ returns the calculated key figures of sentiments between all persons
 | Name      | Description                                                                                    | Allowed Values                 |
 |-----------|------------------------------------------------------------------------------------------------|--------------------------------|
 | session   | Limits the messages used for key figures calculation to only those from the given session      | any sessionId from `/sessions` |
-| exclude_applause | Filters out all messages which are flagged as applause                                  | `true`                       |
+| excludeApplause | Filters out all messages which are flagged as applause                                   | `true`                       |
 
 
 #### Sample Data

--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ QUERY_PARAM_FILTER = 'filter'
 QUERY_PARAM_SESSION = 'session'
 QUERY_PARAM_PERSON = 'person'
 QUERY_PARAM_REVERSE = 'reverse'
+QUERY_PARAM_EXCLUDE_APPLAUSE = 'excludeApplause'
 
 
 def generate_cache_key():
@@ -38,6 +39,8 @@ def generate_cache_key():
     sentiment_filter = request.args.get(QUERY_PARAM_FILTER)
     person = request.args.get(QUERY_PARAM_PERSON)
     reverse = request.args.get(QUERY_PARAM_REVERSE)
+    exclude_applause = request.args.get(QUERY_PARAM_EXCLUDE_APPLAUSE)
+
     if sentiment_filter is not None:
         cache_key += ':' + sentiment_filter
     if session is not None:
@@ -46,6 +49,9 @@ def generate_cache_key():
         cache_key += ':' + person
     if reverse is not None:
         cache_key += ':' + reverse
+    if exclude_applause is not None:
+        cache_key += ':' + exclude_applause
+
     return cache_key
 
 
@@ -61,14 +67,16 @@ def get_persons():
 @cache.cached(make_cache_key=generate_cache_key)
 def get_messages():
     return jsonify(group4_db.get_messages(request.args.get(QUERY_PARAM_FILTER), request.args.get(QUERY_PARAM_SESSION),
-                                          request.args.get(QUERY_PARAM_PERSON)))
+                                          request.args.get(QUERY_PARAM_PERSON),
+                                          request.args.get(QUERY_PARAM_EXCLUDE_APPLAUSE) == 'true'))
 
 
 @app.route('/persons/graph')
 @cache.cached(make_cache_key=generate_cache_key)
 def get_persons_graph():
     return jsonify(group4_db.get_graph(request.args.get(QUERY_PARAM_FILTER), request.args.get(QUERY_PARAM_SESSION),
-                                       request.args.get(QUERY_PARAM_PERSON)))
+                                       request.args.get(QUERY_PARAM_PERSON),
+                                       request.args.get(QUERY_PARAM_EXCLUDE_APPLAUSE) == 'true'))
 
 
 @app.route('/persons/ranked')
@@ -76,13 +84,15 @@ def get_persons_graph():
 def get_persons_ranked():
     return jsonify(
         group4_db.get_persons_ranked(request.args.get(QUERY_PARAM_FILTER), request.args.get(QUERY_PARAM_SESSION),
-                                     request.args.get(QUERY_PARAM_REVERSE) == 'true'))
+                                     request.args.get(QUERY_PARAM_REVERSE) == 'true',
+                                     request.args.get(QUERY_PARAM_EXCLUDE_APPLAUSE) == 'true'))
 
 
 @app.route('/persons/sentiment/key_figures')
 @cache.cached(make_cache_key=generate_cache_key)
 def get_key_figures_persons():
-    return jsonify(group4_db.get_key_figures(session_id=request.args.get(QUERY_PARAM_SESSION)))
+    return jsonify(group4_db.get_key_figures(session_id=request.args.get(QUERY_PARAM_SESSION),
+                                             exclude_applause=request.args.get(QUERY_PARAM_EXCLUDE_APPLAUSE) == 'true'))
 
 
 # GROUP 5 endpoints
@@ -95,7 +105,8 @@ def get_factions():
 @app.route('/factions/graph')
 @cache.cached(make_cache_key=generate_cache_key)
 def get_faction_graph():
-    return jsonify(group5_db.get_graph(request.args.get(QUERY_PARAM_FILTER), request.args.get(QUERY_PARAM_SESSION)))
+    return jsonify(group5_db.get_graph(request.args.get(QUERY_PARAM_FILTER), request.args.get(QUERY_PARAM_SESSION),
+                                       request.args.get(QUERY_PARAM_EXCLUDE_APPLAUSE) == 'true'))
 
 
 @app.route('/factions/ranked')
@@ -103,19 +114,22 @@ def get_faction_graph():
 def get_factions_ranked():
     return jsonify(
         group5_db.get_factions_ranked(request.args.get(QUERY_PARAM_FILTER), request.args.get(QUERY_PARAM_SESSION),
-                                      request.args.get(QUERY_PARAM_REVERSE) == 'true'))
+                                      request.args.get(QUERY_PARAM_REVERSE) == 'true',
+                                      request.args.get(QUERY_PARAM_EXCLUDE_APPLAUSE) == 'true'))
 
 
 @app.route('/factions/sentiment/key_figures')
 @cache.cached(make_cache_key=generate_cache_key)
 def get_key_figures_factions():
-    return jsonify(group5_db.get_key_figures(session_id=request.args.get(QUERY_PARAM_SESSION)))
+    return jsonify(group5_db.get_key_figures(session_id=request.args.get(QUERY_PARAM_SESSION),
+                                             exclude_applause=request.args.get(QUERY_PARAM_EXCLUDE_APPLAUSE) == 'true'))
 
 
 @app.route('/factions/proportions')
 @cache.cached(make_cache_key=generate_cache_key)
 def get_faction_proportions():
-    return jsonify(group5_db.get_faction_proportions(request.args.get(QUERY_PARAM_SESSION)))
+    return jsonify(group5_db.get_faction_proportions(request.args.get(QUERY_PARAM_SESSION),
+                                                     request.args.get(QUERY_PARAM_EXCLUDE_APPLAUSE) == 'true'))
 
 
 # MIXED endpoints

--- a/database/Group5Database.py
+++ b/database/Group5Database.py
@@ -21,19 +21,19 @@ class Group5Database(Database):
                     "RETURN DISTINCT sender.name as name, sender.size as size, sender.factionId as factionId, " \
                     "sessionList as sessionIds" \
                 .format(NODE_FACTION, REL_COMMENTED, where)
-            print(query)
+
             factions = session.run(query)
             return factions.data()
 
-    def get_graph(self, sentiment_type="NEUTRAL", session_id=None):
+    def get_graph(self, sentiment_type="NEUTRAL", session_id=None, exclude_applause=False):
         factions = self.get_factions(sentiment_type, session_id)
-        messages = self.get_messages(sentiment_type, session_id)
+        messages = self.get_messages(sentiment_type, session_id, exclude_applause)
         return {
             'factions': factions,
             'messages': messages
         }
 
-    def get_key_figures(self, session_id):
+    def get_key_figures(self, session_id, exclude_applause=False):
         sentiments = []
         highest_sentiment = None
         lowest_sentiment = None
@@ -41,7 +41,7 @@ class Group5Database(Database):
         sentiment_lower_quartile = None
         sentiment_upper_quartile = None
 
-        messages = self.get_plain_messages(session_id)
+        messages = self.get_plain_messages(session_id, exclude_applause)
         for message in messages:
             if message['sentiment'] is not None:
                 sentiments.append(message['sentiment'])
@@ -64,11 +64,18 @@ class Group5Database(Database):
             'sentiment_upper_quartile': sentiment_upper_quartile
         }
 
-    def get_plain_messages(self, session_id=None):
+    def get_plain_messages(self, session_id=None, exclude_applause=False):
 
         where = ''
         if session_id is not None:
             where = 'WHERE r.sessionId={0}'.format(session_id)
+
+        if exclude_applause is True:
+            if len(where) > 0:
+                where = where + ' AND '
+            else:
+                where = where + ' WHERE '
+            where = where + 'COALESCE(r.applause, false) <> true'
 
         with self.driver.session() as session:
             query = 'MATCH p=(sender)-[r:{0}]->(recipient) ' \
@@ -76,8 +83,8 @@ class Group5Database(Database):
                     'RETURN r.polarity as sentiment'.format(REL_COMMENTED, where)
             return session.run(query).data()
 
-    def get_messages(self, sentiment_type="NEUTRAL", session_id=None):
-        where = self.get_where_clause(sentiment_type, session_id)
+    def get_messages(self, sentiment_type="NEUTRAL", session_id=None, exclude_applause=False):
+        where = self.get_where_clause(sentiment_type, session_id, None, exclude_applause)
         with self.driver.session() as session:
             query = 'MATCH p=(sender:{0})-[r:{1}]->(recipient:{0}) ' \
                     '{2}' \
@@ -85,18 +92,18 @@ class Group5Database(Database):
                     'collect(distinct r.sessionId) as sessionList, ' \
                     'collect(r) as rlist unwind rlist as r ' \
                     'RETURN sender.factionId as sender, recipient.factionId as recipient, ' \
-                    'count(r) as count, sum((r.weight/weightsum)*r.polarity) as sentiment, sessionList as sessionIds' \
+                    'count(r) as count, sum((r.weight/weightsum)*r.polarity) as sentiment' \
                 .format(NODE_FACTION, REL_COMMENTED, where)
 
             return session.run(query).data()
 
-    def get_factions_ranked(self, sentiment_type, session_id=None, reverse=None):
+    def get_factions_ranked(self, sentiment_type, session_id=None, reverse=None, exclude_applause=False):
         factions = self.get_factions()
-        messages = self.get_messages(sentiment_type, session_id)
+        messages = self.get_messages(sentiment_type, session_id, exclude_applause)
         ranked = calculate_pagerank_eigenvector(factions, messages, field_name='factionId', reverse=reverse)
         return sorted(ranked, key=lambda x: x['rank'], reverse=True)
 
-    def get_where_clause(self, sentiment_type="NEUTRAL", session_id=None, faction_id=None):
+    def get_where_clause(self, sentiment_type="NEUTRAL", session_id=None, faction_id=None, exclude_applause=False):
         where = 'WHERE NOT sender.factionId = recipient.factionId '
         if faction_id is not None:
             where = where + "AND sender.factionId= '{0}' ".format(faction_id)
@@ -110,15 +117,19 @@ class Group5Database(Database):
         if sentiment_type == 'NEGATIVE':
             where = where + " AND r.polarity < 0 "
 
+        if exclude_applause is True:
+            where = where + " AND COALESCE(r.applause, false) <> true "
+
         return where
 
-    def get_faction_proportions(self, session_id=None):
+    def get_faction_proportions(self, session_id=None, exclude_applause=False):
         with self.driver.session() as session:
             proportions = []
             total_send_messages = 0
             faction_ids = session.run('MATCH (n:Faction) RETURN n.factionId as factionId').data()
             for id in faction_ids:
-                where = self.get_where_clause(session_id=session_id, faction_id=id['factionId'])
+                where = self.get_where_clause(session_id=session_id, faction_id=id['factionId'],
+                                              exclude_applause=exclude_applause)
                 query = "MATCH (sender:{0})-[r:{1}]-(recipient:{0}) " \
                         "{2}" \
                         "RETURN sender.name as name, sender.size as size, sender.factionId as factionId, " \

--- a/pagerank.py
+++ b/pagerank.py
@@ -17,6 +17,9 @@ def aggregate_messages(messages):
         else:
             result.append({'sender': message['sender'], 'recipient': message['recipient'], 'count': 1, 'sentiment': message['sentiment'], 'sessionIds': [message['sessionId']]})
 
+    for m in result:
+        m['sentiment'] = m['sentiment'] / m['count']
+
     return result
 
 


### PR DESCRIPTION
Ich habe es jetzt so gebaut, dass man es bei fast allen Endpoints mitgeben kann.

Ich habe außerdem beim Aggregieren der messages für den person graph eingebaut, dass hier der Durchschnitt der Sentiments verwendet wird, anstatt die Summe der Sentiments. Für die Darstellung werden am Ende Werte zwischen -1 und 1 gebraucht und wenn wir hier Aufsummieren kann es zu einem Überlauf kommen. Außerdem sind die Werte im faction Graph auch bereits in diesem Wertebereich (da passiert es in der Query, die uns Gruppe 5 bereitgestellt hat)