### PR TITLE
adjust message aggregation to improve performance

### DIFF
--- a/database/Group4Database.py
+++ b/database/Group4Database.py
@@ -119,7 +119,7 @@ class Group4Database(Database):
 
     def get_persons_ranked(self, sentiment_type, session_id=None, reverse=None, exclude_applause=False):
         persons = self.get_persons()
-        messages = self.get_messages(sentiment_type, session_id, exclude_applause)
+        messages = self.get_messages(sentiment_type, session_id, None, exclude_applause)
         ranked = calculate_pagerank_eigenvector(persons, aggregate_messages(messages), reverse=reverse)
         return sorted(ranked, key=lambda x: x['rank'], reverse=True)
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,6 +18,10 @@ http {
     keepalive_timeout   65;
     types_hash_max_size 2048;
 
+    gzip             on;
+    gzip_comp_level  9;
+    gzip_types       application/json;
+
     include             /etc/nginx/mime.types;
     default_type        application/octet-stream;
 

--- a/pagerank.py
+++ b/pagerank.py
@@ -2,20 +2,22 @@ import numpy as np
 
 
 def aggregate_messages(messages):
-    result = []
+    existing_entries = {}
     for message in messages:
-        existing_entries = [x for x in result if (x['sender'] == message['sender'] and x['recipient'] == message['recipient'])]
-        if len(existing_entries) > 0:
-            entry = existing_entries[0]
-            count = entry['count'] + 1
-            sentiment = entry['sentiment'] + message['sentiment']
-            entry['count'] = count
-            entry['sentiment'] = sentiment
-            if message['sessionId'] not in entry['sessionIds']:
-                entry['sessionIds'].append(message['sessionId'])
+        message_key = message['sender']+':'+message['recipient']
+        try:
+            existing_entry = existing_entries[message_key]
+            count = existing_entry['count'] + 1
+            sentiment = existing_entry['sentiment'] + message['sentiment']
+            existing_entry['count'] = count
+            existing_entry['sentiment'] = sentiment
 
-        else:
-            result.append({'sender': message['sender'], 'recipient': message['recipient'], 'count': 1, 'sentiment': message['sentiment'], 'sessionIds': [message['sessionId']]})
+        except KeyError:
+            new_entry = {'sender': message['sender'], 'recipient': message['recipient'], 'count': 1,
+                         'sentiment': message['sentiment']}
+            existing_entries[message['sender'] + ':' + message['recipient']] = new_entry
+
+    result = list(existing_entries.values())
 
     for m in result:
         m['sentiment'] = m['sentiment'] / m['count']

--- a/pagerank.py
+++ b/pagerank.py
@@ -15,7 +15,7 @@ def aggregate_messages(messages):
         except KeyError:
             new_entry = {'sender': message['sender'], 'recipient': message['recipient'], 'count': 1,
                          'sentiment': message['sentiment']}
-            existing_entries[message['sender'] + ':' + message['recipient']] = new_entry
+            existing_entries[message_key] = new_entry
 
     result = list(existing_entries.values())
 


### PR DESCRIPTION
Wir haben jetzt die echte Datenmenge in der Datenbank von Gruppe 4 und das führte erstmal zu massiven Performance Problemen. Ich habe als Quelle die Funktion `aggregate_messages` als einen der Hauptverantwortlichen gemacht und diese mal optimiert. Die Version läuft aktuell auf dem Server und ist zumindest in der Lage, die Requests zu bedienen. Zuvor kam es regelmäßig zu einem `504 | Gateway Timeout`